### PR TITLE
Allow enforcing min version

### DIFF
--- a/lib/cm_api.rb
+++ b/lib/cm_api.rb
@@ -8,6 +8,9 @@ module CMAPI
   # An error that's raised when the version of CDH is not valid
   InvalidCDHVersionError = Class.new(StandardError)
 
+  # An error that's raised when a call is not supported for the specified API version
+  UnsupportedVersionError = Class.new(StandardError)
+
   autoload :VERSION, "cm_api/version"
   autoload :Client, "cm_api/client"
   autoload :Middleware, "cm_api/middleware"

--- a/lib/cm_api/client.rb
+++ b/lib/cm_api/client.rb
@@ -169,5 +169,9 @@ module CMAPI
     def secure?
       !!https
     end
+
+    def enforce_min_version!(api_version)
+      raise UnsupportedVersionError, "Only versions >= #{api_version} are supported." unless version >= api_version
+    end
   end
 end

--- a/lib/cm_api/client/clusters.rb
+++ b/lib/cm_api/client/clusters.rb
@@ -46,11 +46,13 @@ module CMAPI
 
       # Rename an existing cluster
       # @see http://cloudera.github.io/cm_api/apidocs/v13/path__clusters_-clusterName-.html
+      # @raise [UnsupportedVersionError] when version < 2
       #
       # @param name [String] the name of the existing cluster
       # @param new_name [String] the new name for the cluster
       # @return [Resources::Base] the updated cluster
       def rename_cluster(name:, new_name:)
+        enforce_min_version!(2)
         body = { displayName: new_name }
         body = { name: new_name } if version < 6
 
@@ -59,11 +61,13 @@ module CMAPI
 
       # Update the CDH version for a cluster.
       # @see http://cloudera.github.io/cm_api/apidocs/v13/path__clusters_-clusterName-.html
+      # @raise [UnsupportedVersionError] when version < 2
       #
       # @param name [String] the name of the cluster
       # @param full_version [String] the full version for the cluster (e.g. 5.8.1)
       # @return [Resources::Base] the updated cluster
       def update_cluster_version(name:, full_version:)
+        enforce_min_version!(2)
         put("/clusters/#{name}", body: { fullVersion: full_version })
       end
 

--- a/spec/cassettes/CMAPI_Client/_rename_cluster/when_the_API_version_2/raises_UnsupportedVersionError.yml
+++ b/spec/cassettes/CMAPI_Client/_rename_cluster/when_the_API_version_2/raises_UnsupportedVersionError.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:7180/api/v13/clusters
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"name":"Version Test","version":null,"fullVersion":"5.8.1"}]}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic Y2xvdWRlcmE6Y2xvdWRlcmE=
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 01-Jan-1970 00:00:00 GMT
+      Set-Cookie:
+      - CLOUDERA_MANAGER_SESSIONID=v1agt9qe11bttdrgzi5827i8;Path=/;HttpOnly
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 30 Aug 2016 09:23:04 GMT
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(6.1.26.cloudera.4)
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "items" : [ {
+            "name" : "Version Test",
+            "displayName" : "Version Test",
+            "version" : "CDH5",
+            "fullVersion" : "5.8.1",
+            "maintenanceMode" : false,
+            "maintenanceOwners" : [ ],
+            "clusterUrl" : "http://quickstart.cloudera:7180/cmf/clusterRedirect/Version+Test",
+            "hostsUrl" : "http://quickstart.cloudera:7180/cmf/clusterRedirect/Version+Test/hosts"
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 20:52:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/CMAPI_Client/_rename_cluster/when_the_cluster_exists/updates_the_name.yml
+++ b/spec/cassettes/CMAPI_Client/_rename_cluster/when_the_cluster_exists/updates_the_name.yml
@@ -25,11 +25,11 @@ http_interactions:
       Expires:
       - Thu, 01-Jan-1970 00:00:00 GMT
       Set-Cookie:
-      - CLOUDERA_MANAGER_SESSIONID=1mcvhcil1mvavgr3maxefqc9e;Path=/;HttpOnly
+      - CLOUDERA_MANAGER_SESSIONID=1ujs7nlp6oqfq1md2iz3mnr0v5;Path=/;HttpOnly
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Aug 2016 07:31:50 GMT
+      - Tue, 30 Aug 2016 09:23:04 GMT
       Transfer-Encoding:
       - chunked
       Server:
@@ -50,7 +50,7 @@ http_interactions:
           } ]
         }
     http_version: 
-  recorded_at: Thu, 01 Sep 2016 18:01:03 GMT
+  recorded_at: Thu, 01 Sep 2016 20:52:30 GMT
 - request:
     method: put
     uri: http://localhost:7180/api/v13/clusters/To%20Be%20Updated
@@ -76,11 +76,11 @@ http_interactions:
       Expires:
       - Thu, 01-Jan-1970 00:00:00 GMT
       Set-Cookie:
-      - CLOUDERA_MANAGER_SESSIONID=36y6om32jy95qg7quz9pl2zu;Path=/;HttpOnly
+      - CLOUDERA_MANAGER_SESSIONID=1af77p6yr0yzk1fnbhh8moefp9;Path=/;HttpOnly
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Aug 2016 07:31:50 GMT
+      - Tue, 30 Aug 2016 09:23:04 GMT
       Transfer-Encoding:
       - chunked
       Server:
@@ -99,5 +99,5 @@ http_interactions:
           "hostsUrl" : "http://quickstart.cloudera:7180/cmf/clusterRedirect/To+Be+Updated/hosts"
         }
     http_version: 
-  recorded_at: Thu, 01 Sep 2016 18:01:03 GMT
+  recorded_at: Thu, 01 Sep 2016 20:52:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/CMAPI_Client/_rename_cluster/when_the_cluster_is_not_found/returns_the_error_resource.yml
+++ b/spec/cassettes/CMAPI_Client/_rename_cluster/when_the_cluster_is_not_found/returns_the_error_resource.yml
@@ -25,11 +25,11 @@ http_interactions:
       Expires:
       - Thu, 01-Jan-1970 00:00:00 GMT
       Set-Cookie:
-      - CLOUDERA_MANAGER_SESSIONID=12xaxy8l6p8vovr8m7xs6cl73;Path=/;HttpOnly
+      - CLOUDERA_MANAGER_SESSIONID=1lo32vc6r4ishgq2n3footzno;Path=/;HttpOnly
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Aug 2016 07:42:20 GMT
+      - Tue, 30 Aug 2016 09:23:04 GMT
       Transfer-Encoding:
       - chunked
       Server:
@@ -41,5 +41,5 @@ http_interactions:
           "message" : "Cluster 'Not here' not found."
         }
     http_version: 
-  recorded_at: Thu, 01 Sep 2016 18:11:32 GMT
+  recorded_at: Thu, 01 Sep 2016 20:52:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/CMAPI_Client/_update_cluster_version/when_the_API_version_2/raises_UnsupportedVersionError.yml
+++ b/spec/cassettes/CMAPI_Client/_update_cluster_version/when_the_API_version_2/raises_UnsupportedVersionError.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:7180/api/v13/clusters
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"name":"Update Cluster Version Test","version":null,"fullVersion":"5.8.1"}]}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic Y2xvdWRlcmE6Y2xvdWRlcmE=
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 01-Jan-1970 00:00:00 GMT
+      Set-Cookie:
+      - CLOUDERA_MANAGER_SESSIONID=43mx4px1gf0q1s9gike9wa9n8;Path=/;HttpOnly
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 30 Aug 2016 09:28:15 GMT
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(6.1.26.cloudera.4)
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "items" : [ {
+            "name" : "Update Cluster Version Test",
+            "displayName" : "Update Cluster Version Test",
+            "version" : "CDH5",
+            "fullVersion" : "5.8.1",
+            "maintenanceMode" : false,
+            "maintenanceOwners" : [ ],
+            "clusterUrl" : "http://quickstart.cloudera:7180/cmf/clusterRedirect/Update+Cluster+Version+Test",
+            "hostsUrl" : "http://quickstart.cloudera:7180/cmf/clusterRedirect/Update+Cluster+Version+Test/hosts"
+          } ]
+        }
+    http_version: 
+  recorded_at: Thu, 01 Sep 2016 20:57:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/CMAPI_Client/_update_cluster_version/when_the_cluster_exists/updates_the_version_of_CDH_for_the_cluster.yml
+++ b/spec/cassettes/CMAPI_Client/_update_cluster_version/when_the_cluster_exists/updates_the_version_of_CDH_for_the_cluster.yml
@@ -25,11 +25,11 @@ http_interactions:
       Expires:
       - Thu, 01-Jan-1970 00:00:00 GMT
       Set-Cookie:
-      - CLOUDERA_MANAGER_SESSIONID=1n88bzx6n7lc4tljtlubsdp1e;Path=/;HttpOnly
+      - CLOUDERA_MANAGER_SESSIONID=1g0r8949b1jrkjmx888gtkc;Path=/;HttpOnly
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Aug 2016 07:51:26 GMT
+      - Tue, 30 Aug 2016 09:23:04 GMT
       Transfer-Encoding:
       - chunked
       Server:
@@ -50,7 +50,7 @@ http_interactions:
           } ]
         }
     http_version: 
-  recorded_at: Thu, 01 Sep 2016 18:20:39 GMT
+  recorded_at: Thu, 01 Sep 2016 20:52:31 GMT
 - request:
     method: put
     uri: http://localhost:7180/api/v13/clusters/Update%20CDH
@@ -76,11 +76,11 @@ http_interactions:
       Expires:
       - Thu, 01-Jan-1970 00:00:00 GMT
       Set-Cookie:
-      - CLOUDERA_MANAGER_SESSIONID=123rxyldekfu1xpc34wmnnlvu;Path=/;HttpOnly
+      - CLOUDERA_MANAGER_SESSIONID=gconlebalxzm19h1pmc2zj2xp;Path=/;HttpOnly
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Aug 2016 07:51:26 GMT
+      - Tue, 30 Aug 2016 09:23:04 GMT
       Transfer-Encoding:
       - chunked
       Server:
@@ -99,5 +99,5 @@ http_interactions:
           "hostsUrl" : "http://quickstart.cloudera:7180/cmf/clusterRedirect/Update+CDH/hosts"
         }
     http_version: 
-  recorded_at: Thu, 01 Sep 2016 18:20:39 GMT
+  recorded_at: Thu, 01 Sep 2016 20:52:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/CMAPI_Client/_update_cluster_version/when_the_cluster_is_not_found/returns_the_error_resource.yml
+++ b/spec/cassettes/CMAPI_Client/_update_cluster_version/when_the_cluster_is_not_found/returns_the_error_resource.yml
@@ -25,11 +25,11 @@ http_interactions:
       Expires:
       - Thu, 01-Jan-1970 00:00:00 GMT
       Set-Cookie:
-      - CLOUDERA_MANAGER_SESSIONID=7t7kap80vk0h2gqvy9rsrgfh;Path=/;HttpOnly
+      - CLOUDERA_MANAGER_SESSIONID=4y699bf421iw168x2uxvld1ne;Path=/;HttpOnly
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Aug 2016 07:51:26 GMT
+      - Tue, 30 Aug 2016 09:23:05 GMT
       Transfer-Encoding:
       - chunked
       Server:
@@ -41,5 +41,5 @@ http_interactions:
           "message" : "Cluster 'Not here' not found."
         }
     http_version: 
-  recorded_at: Thu, 01 Sep 2016 18:20:39 GMT
+  recorded_at: Thu, 01 Sep 2016 20:52:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cm_api/client/clusters_spec.rb
+++ b/spec/cm_api/client/clusters_spec.rb
@@ -81,6 +81,18 @@ describe CMAPI::Client, :vcr do
         expect(response.message).to_not be_empty
       end
     end
+
+    context "when the API version < 2" do
+      it "raises UnsupportedVersionError" do
+        APIClient.create_cluster(name: "Version Test", full_version: "5.8.1")
+        expect(last_response.status).to eq(200)
+
+        client = versioned_api_client(version: 1)
+        expect { client.rename_cluster(name: "Version Test", new_name: "Doesn't Matter") }.to raise_error(
+          CMAPI::UnsupportedVersionError
+        )
+      end
+    end
   end
 
   describe "#update_cluster_version" do
@@ -100,6 +112,18 @@ describe CMAPI::Client, :vcr do
         response = APIClient.update_cluster_version(name: "Not here", full_version: "5.8.1")
         expect(last_response.status).to eq(404)
         expect(response.message).to_not be_empty
+      end
+    end
+
+    context "when the API version < 2" do
+      it "raises UnsupportedVersionError" do
+        APIClient.create_cluster(name: "Update Cluster Version Test", full_version: "5.8.1")
+        expect(last_response.status).to eq(200)
+
+        client = versioned_api_client(version: 1)
+        expect { client.rename_cluster(name: "Update Cluster Version Test", new_name: "Meh") }.to raise_error(
+          CMAPI::UnsupportedVersionError
+        )
       end
     end
   end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 APIClient = CMAPI::Client.new(host: "localhost", user: "cloudera", pass: "cloudera")
 
+def versioned_api_client(version:)
+  CMAPI::Client.new(host: "localhost", user: "cloudera", pass: "cloudera", version: version)
+end
+
 def last_response
   APIClient.last_response
 end


### PR DESCRIPTION
# The Problem

Certain endpoints, like `update cluster` require that the target version be at least 2. Currently this is not enforced, but really should be.

No need to make the call only to be told it's not supported. 
# The Solution

Raise `UnsupportedVersionError` when `enforce_min_version!` determines the current version is < the minimum supported one.
